### PR TITLE
Small optimizations to IO

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -153,7 +153,7 @@ StellarModels.set_options!(sm.opt, "./example_options.toml")
 rm(sm.opt.io.hdf5_history_filename; force=true)
 rm(sm.opt.io.hdf5_profile_filename; force=true)
 StellarModels.n_polytrope_initial_condition!(n, sm, 1*MSUN, 100 * RSUN; initial_dt=1000 * SECYEAR)
-@time Evolution.do_evolution_loop!(sm);
+@time sm = Evolution.do_evolution_loop!(sm);
 
 ##
 #=

--- a/src/Evolution/EvolutionLoop.jl
+++ b/src/Evolution/EvolutionLoop.jl
@@ -100,6 +100,7 @@ Performs the main evolutionary loop of the input StellarModel `sm`. It continues
 termination criteria is reached (defined in `sm.opt.termination`).
 """
 function do_evolution_loop!(sm::StellarModel)
+    StellarModels.create_output_files!(sm)
     set_step_info!(sm, sm.esi)
     # evolution loop, be sure to have sensible termination conditions or this will go on forever!
     dt_factor = 1.0 # this is changed during retries to lower the timestep
@@ -223,5 +224,6 @@ function do_evolution_loop!(sm::StellarModel)
     if sm.opt.plotting.do_plotting
         Plotting.end_of_evolution(sm)
     end
-
+    StellarModels.close_output_files!(sm)
+    return sm
 end

--- a/src/StellarModels/Options.jl
+++ b/src/StellarModels/Options.jl
@@ -67,11 +67,13 @@ Substructure of Options containing controls relating to input/output of data
     hdf5_history_filename::String = "history.hdf5"
     hdf5_history_chunk_size::Int = 50
     hdf5_history_compression_level::Int = 9
+    hdf5_history_keep_open::Bool = false
 
     hdf5_profile_filename::String = "profiles.hdf5"
     hdf5_profile_chunk_size::Int = 50
     hdf5_profile_compression_level::Int = 9
     hdf5_profile_dataset_name_zero_padding::Int = 10
+    hdf5_profile_keep_open::Bool = false
 
     terminal_header_interval::Int = 10
     terminal_info_interval::Int = 10

--- a/src/StellarModels/StellarModel.jl
+++ b/src/StellarModels/StellarModel.jl
@@ -1,6 +1,7 @@
 using FunctionWrappers
 using ForwardDiff
 using LinearAlgebra
+using HDF5
 using Jems.DualSupport
 
 """
@@ -148,6 +149,10 @@ differentiation, `TEOS` for the type of EOS being used and `TKAP` for the type o
 
     # object holding plotting things, ie figures, data to plot.
     plt::Plotter
+
+    # Output files
+    history_file::HDF5.File
+    profiles_file::HDF5.File
 end
 
 """
@@ -220,7 +225,9 @@ function StellarModel(var_names::Vector{Symbol},
                       remesh_split_functions=remesh_split_functions,
                       time=zero(number_type), dt=zero(number_type), model_number=0,
                       eos=eos, opacity=opacity, network=network, props=props,
-                      psi=psi, ssi=ssi, esi=esi, opt=opt, plt=plt)
+                      psi=psi, ssi=ssi, esi=esi, opt=opt, plt=plt,
+                      history_file = HDF5.File(-1,""),
+                      profiles_file = HDF5.File(-1,""))
 
     return sm
 end
@@ -264,6 +271,9 @@ function adjusted_stellar_model_data(sm, new_nz::Int, new_nextra::Int)
     new_sm.model_number = sm.model_number
     new_sm.mstar = sm.mstar
     new_sm.plt = sm.plt
+
+    new_sm.history_file = sm.history_file
+    new_sm.profiles_file = sm.profiles_file
 
     # copy arrays
     for i in 1:sm.nz


### PR DESCRIPTION
This allows for HDF5 files to be kept open, saving a bit of time in IO at the risk of the process being terminated and the file not being closed.

It also adapts how output options are managed, and adds simple functions to add new profile and history output.