### PR TITLE
Adjusted treatment of solver tolerances and equation scaling

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -121,7 +121,7 @@ open("example_options.toml", "w") do file
 
           [termination]
           max_model_number = 2000
-          max_center_T = 4e7
+          max_center_T = 1e8
 
           [plotting]
           do_plotting = false
@@ -152,7 +152,7 @@ end
 StellarModels.set_options!(sm.opt, "./example_options.toml")
 rm(sm.opt.io.hdf5_history_filename; force=true)
 rm(sm.opt.io.hdf5_profile_filename; force=true)
-StellarModels.n_polytrope_initial_condition!(n, sm, 1*MSUN, 100 * RSUN; initial_dt=1000 * SECYEAR)
+StellarModels.n_polytrope_initial_condition!(n, sm, 1*MSUN, 100 * RSUN; initial_dt=100 * SECYEAR)
 @time sm = Evolution.do_evolution_loop!(sm);
 
 ##

--- a/src/Evolution/Equations.jl
+++ b/src/Evolution/Equations.jl
@@ -146,9 +146,9 @@ function equationLuminosity(sm::StellarModel, k::Int)
     end
     if k > 1
         L₋ = get_m1_dual(sm.props.L[k-1]) * LSUN
-        return ((L₀ - L₋) / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)  # no neutrinos
+        return ((L₀ - L₋) / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)/(L₀/sm.m[k])  # no neutrinos
     else
-        return (L₀ / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)  # no neutrinos
+        return (L₀ / sm.dm[k] - ϵnuc + cₚ * dTdt - (δ / ρ₀) * dPdt)/(L₀/sm.m[k])  # no neutrinos
     end
 end
 """

--- a/src/Evolution/EvolutionLoop.jl
+++ b/src/Evolution/EvolutionLoop.jl
@@ -135,29 +135,31 @@ function do_evolution_loop!(sm::StellarModel)
             eval_jacobian_eqs!(sm)  # heavy lifting happens here!
             thomas_algorithm!(sm)  # here as well
             corr = @view sm.solver_data.solver_corr[1:sm.nvars*sm.nz]
+            equs = @view sm.solver_data.eqs_numbers[1:sm.nvars*sm.nz]
 
-            real_max_corr = maximum(corr)
+            (abs_max_corr, i_corr) = findmax(abs, corr)
+            corr_nz = i_corr÷sm.nvars + 1
+            corr_equ = i_corr%sm.nvars
+            rel_corr = abs_max_corr/eps(sm.ind_vars[i_corr])
 
-            # scale surface correction to prevent negative surface luminosity
-            # if correction will produce negative L, scale it so L is halved
-            corr_lum_surf = corr[sm.nvars * (sm.nz - 1) + sm.vari[:lum]]
-            lum_surf = sm.ind_vars[sm.nvars * (sm.nz - 1) + sm.vari[:lum]]
-            if lum_surf + corr_lum_surf < 0.0
-                corr = corr * (-0.1 * lum_surf / corr_lum_surf)
-            end
+            (max_res, i_res) = findmax(abs, equs)
+            res_nz = i_res÷sm.nvars + 1
+            res_equ = i_res%sm.nvars
 
             # scale correction
             if sm.model_number == 0
-                corr .*= min(1, sm.opt.solver.initial_model_scale_max_correction / maximum(corr))
+                corr .*= min(1, sm.opt.solver.initial_model_scale_max_correction / abs_max_corr)
             else
-                corr .*= min(1, sm.opt.solver.scale_max_correction / maximum(corr))
+                corr .*= min(1, sm.opt.solver.scale_max_correction / abs_max_corr)
             end
-            if i % 50 == 0
-                @show i, maximum(corr), real_max_corr, maximum(sm.eqs_numbers)
+            if sm.opt.solver.report_solver_progress &&
+                i % sm.opt.solver.solver_progress_iter == 0
+                @show sm.model_number, i, rel_corr, corr_nz, corr_equ, max_res, res_nz, res_equ
             end
             # first try applying correction and see if it would give negative luminosity
             sm.ind_vars[1:sm.nvars*sm.nz] .+= corr[1:sm.nvars*sm.nz]
-            if real_max_corr < 1e-10
+            if rel_corr < sm.opt.solver.relative_correction_tolerance &&
+                    max_res < sm.opt.solver.maximum_residual_tolerance
                 if sm.model_number == 0
                     println("Found first model")
                 end

--- a/src/StellarModels/Options.jl
+++ b/src/StellarModels/Options.jl
@@ -28,7 +28,12 @@ Substructure of Options containing controls relating to the Newton solver
     newton_max_iter_first_step::Int = 5000
     initial_model_scale_max_correction::Float64 = 3.0
     scale_max_correction::Float64 = 0.5
-    scale_correction_negative_Lsurf::Float64 = 0.1
+
+    relative_correction_tolerance::Float64 = 1e3 # measured in terms of variable epsilon, 1 would be machine precision limit, 1e16 is on the scale of the variable
+    maximum_residual_tolerance::Float64 = 1e-4
+
+    report_solver_progress::Bool = true
+    solver_progress_iter::Int = 50
 end
 
 """


### PR DESCRIPTION
This fixes a bug in how the tolerances were determined (before it took a simple maximum so it missed negative large values). Moreover, it switched the tolerance on the solver corrections to be expressed in terms of a set number of minimum representable changes in the corresponding floating point number.

Options have been added to also adapt how the reporting of the progress of the Newton solver is done.