### PR TITLE
Fix reallocation+small adjustements to Newton solver

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -117,7 +117,7 @@ open("example_options.toml", "w") do file
 
           [solver]
           newton_max_iter_first_step = 1000
-          initial_model_scale_max_correction = 0.1
+          initial_model_scale_max_correction = 0.5
           newton_max_iter = 30
           scale_max_correction = 0.1
           report_solver_progress = false

--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -126,7 +126,7 @@ open("example_options.toml", "w") do file
           dt_max_increase = 1.5
           delta_R_limit = 0.01
           delta_Tc_limit = 0.01
-          delta_Xc_limit = 0.002
+          delta_Xc_limit = 0.005
 
           [termination]
           max_model_number = 2000

--- a/src/StellarModels/InitialCondition.jl
+++ b/src/StellarModels/InitialCondition.jl
@@ -164,7 +164,7 @@ function n_polytrope_initial_condition!(n, sm::StellarModel, nz::Int, X, Z, Dfra
     
     logdqs = zeros(length(sm.props.dm))
     for i in 1:nz
-        logdqs[i] = get_logdq(i, nz, -10.0, 0.0, -6.0, 200)
+        logdqs[i] = get_logdq(i, nz, -6.0, 0.0, -6.0, 200)
     end
     dqs = 10 .^ logdqs
     dqs[nz+1:end] .= 0  # extra entries beyond nz have no mass

--- a/src/StellarModels/SolverData.jl
+++ b/src/StellarModels/SolverData.jl
@@ -15,6 +15,7 @@ abstract type AbstractSolverData end
     solver_x::Vector{TVECTOR}
     solver_corr::Vector{TNUMBER}
     newton_iters::Int
+    use_static_arrays::Bool
 end
 
 function SolverData(nvars, nz, nextra, use_static_arrays, number_type)
@@ -69,5 +70,6 @@ function SolverData(nvars, nz, nextra, use_static_arrays, number_type)
                solver_β = solver_β,
                solver_x = solver_x,
                solver_corr = solver_corr,
-               newton_iters = 0)
+               newton_iters = 0,
+               use_static_arrays = use_static_arrays)
 end


### PR DESCRIPTION
Remesher reallocation was broken, should be fixed by this. This also moves things a bit in the newton solver loop to do the following:
- check for residuals before doing the linear solve. If we have a solution we do not need to run the solver again.
- have a try/catch when evaluating stellar model properties. This allows us to retry if the corrections lead to a state that produces an exception (eg if you end up taking the square root of a negative number).