### PR TITLE
Optimize jacobian fillup

### DIFF
--- a/src/Evolution/Equations.jl
+++ b/src/Evolution/Equations.jl
@@ -195,13 +195,14 @@ function equation_composition(sm::StellarModel, k::Int, iso_name::Symbol)
     reactions_in = sm.network.species_reactions_in[sm.network.xa_index[iso_name]]
     for reaction_in in reactions_in
         rate = get_00_dual(sm.props.rates[k,reaction_in[1]])
-        dXdt_nuc = dXdt_nuc - rate*reaction_in[2]*Chem.isotope_list[iso_name].A*AMU
+        dXdt_nuc = dXdt_nuc - rate*reaction_in[2]
     end
     reactions_out = sm.network.species_reactions_out[sm.network.xa_index[iso_name]]
     for reaction_out in reactions_out
         rate = get_00_dual(sm.props.rates[k,reaction_out[1]])
-        dXdt_nuc = dXdt_nuc + rate*reaction_out[2]*Chem.isotope_list[iso_name].A*AMU
+        dXdt_nuc = dXdt_nuc + rate*reaction_out[2]
     end
+    dXdt_nuc = dXdt_nuc*Chem.isotope_list[iso_name].A*AMU
 
     #mixing terms
     flux_down::typeof(X00) = 0

--- a/src/ReactionRates/KippRates.jl
+++ b/src/ReactionRates/KippRates.jl
@@ -53,6 +53,7 @@ Output:
 """
 function get_reaction_rate(reaction::KippReactionRate, T::T1, ρ::T2, xa::AbstractVector{TT},
                            xa_index::Dict{Symbol,Int})::TT where {TT,T1,T2}
+    ϵnuc::TT = 0
     if reaction.name == :kipp_pp
         phi = 1
         f_11 = 1


### PR DESCRIPTION
Using a bit of black arts to make the fillup of the jacobian faster. This is still a part of the code that I'd expect to be blazingly fast, so significant optimizations should still be possible in here.

I also removed allocations in the Kipp rates