### PR TITLE
Fix issue with terminal IO preventing models from continuing evolution

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -119,7 +119,7 @@ open("example_options.toml", "w") do file
           delta_Xc_limit = 0.005
 
           [termination]
-          max_model_number = 2000
+          max_model_number = 400
           max_center_T = 1e8
 
           [io]
@@ -130,8 +130,7 @@ open("example_options.toml", "w") do file
           """)
 end
 StellarModels.set_options!(sm.opt, "./example_options.toml")
-rm(sm.opt.io.hdf5_history_filename; force=true)
-rm(sm.opt.io.hdf5_profile_filename; force=true)
+##
 
 ##
 #Configure live plots. To turn off one can use `plotter = Plotting.NullPlotter()`

--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -145,13 +145,14 @@ plots = [Plotting.HRPlot(f[1,1]),
          Plotting.AbundancePlot(f[2,2],net,log_yscale=true, ymin=1e-3),
          Plotting.HistoryPlot(f[1,3], sm, x_name="age", y_name="X_center", othery_name="Y_center", link_yaxes=true),
          Plotting.ProfilePlot(f[2,3], sm, x_name="mass", y_name="log10_rho", othery_name="log10_T")]
-plotter = Plotting.Plotter(fig=f,plots=plots)
+plotter = Plotting.Plotter(fig=f,plots=plots);
 
 ##
 #set initial condition and run model
 n = 3
 StellarModels.n_polytrope_initial_condition!(n, sm, nz, 0.7154, 0.0142, 0.0, Chem.abundance_lists[:ASG_09], 
                                             1 * MSUN, 100 * RSUN; initial_dt=10 * SECYEAR)
+##
 @time Evolution.do_evolution_loop!(sm, plotter=plotter);
 
 ##

--- a/examples/OneZoneBurn.jl
+++ b/examples/OneZoneBurn.jl
@@ -80,7 +80,6 @@ open("example_options.toml", "w") do file
           """)
 end
 StellarModels.set_options!(oz.opt, "./example_options.toml")
-rm(oz.opt.io.hdf5_history_filename; force=true)
 
 using GLMakie
 set_theme!(Plotting.basic_theme())

--- a/src/StellarModels/IO.jl
+++ b/src/StellarModels/IO.jl
@@ -103,14 +103,20 @@ function setup_model_profile_functions!(sm::StellarModel)
     add_profile_option!(sm, "nabla_face", "unitless", (sm, k) -> get_value(sm.props.turb_res[k].∇), label=L"\nabla_\text{face}")
     add_profile_option!(sm, "D_face", "cm^2*s^{-1}", (sm, k) -> get_value(sm.props.turb_res[k].D_turb), label=L"D_\text{face}\,[\text{cm^2\,s^{-1}}]")
 end
-
+# StellarModel has profile information
+function has_profiles(sm::StellarModel)
+    return true
+end
 # One zone does not have profile info
-function setup_model_profile_functions!(oz::OneZone)
+function has_profiles(oz::OneZone)
+    return false
 end
 
 function init_IO(m::AbstractModel)
     setup_model_history_functions!(m)
-    setup_model_profile_functions!(m)
+    if has_profiles(m)
+        setup_model_profile_functions!(m)
+    end
 end
 
 """
@@ -119,6 +125,18 @@ end
 Creates output files for history and profile data
 """
 function create_output_files!(m::AbstractModel, ::Type{TNUMBER}=Float64) where {TNUMBER}
+    if m.output_files_created && m.props.model_number != 0
+        # preserve the already created files
+        # it is assumed that when model_number == 0 we always need to create the files again
+        return
+    end
+
+    # remove any matching files if present
+    rm(m.opt.io.hdf5_history_filename; force=true)
+    if has_profiles(m)
+        rm(m.opt.io.hdf5_profile_filename; force=true)
+    end
+
     # Create history file
     mkpath(dirname(m.opt.io.hdf5_history_filename))
     m.history_file = h5open(m.opt.io.hdf5_history_filename, "w")
@@ -164,7 +182,8 @@ function create_output_files!(m::AbstractModel, ::Type{TNUMBER}=Float64) where {
         close(m.history_file)
     end
 
-    if isa(m, OneZone)
+    if !has_profiles(m)
+        m.output_files_created = true
         return
     end
     
@@ -181,14 +200,18 @@ function create_output_files!(m::AbstractModel, ::Type{TNUMBER}=Float64) where {
     if (!m.opt.io.hdf5_profile_keep_open)
         close(m.profiles_file)
     end
+
+    m.output_files_created = true
 end
 
 function shut_down_IO!(m)
     if (m.opt.io.hdf5_history_keep_open)
         close(m.history_file)
     end
-    if (m.opt.io.hdf5_profile_keep_open)
-        close(m.profiles_file)
+    if has_profiles(m)
+        if (m.opt.io.hdf5_profile_keep_open)
+            close(m.profiles_file)
+        end
     end
 end
 
@@ -249,7 +272,7 @@ function write_data(m::AbstractModel, ::Type{TNUMBER}=Float64) where {TNUMBER}
         end
     end
 
-    if isa(m, OneZone)
+    if !has_profiles(m)
         return
     end
 

--- a/src/StellarModels/IO.jl
+++ b/src/StellarModels/IO.jl
@@ -6,72 +6,6 @@ export add_history_option, add_profile_option,
        history_output_units, history_output_functions, history_output_labels,
        profile_output_units, profile_output_functions, profile_output_labels
 
-ioinit = false
-
-const width = 9
-const decimals = 4
-const floatstr = "%#$width.$decimals" * "g "
-const intstr = "%$width" * "i "
-
-mutable struct TerminalHeader
-    header::String
-    linefmts::Vector{Printf.Format}
-end
-
-const terminal_header = TerminalHeader("", [])
-
-function setup_header(sm::StellarModel)
-    terminal_header.linefmts = Vector{String}(undef, 2)
-    terminal_header.linefmts[1] = Printf.Format(intstr * floatstr^6 * intstr * "\n")
-    terminal_header.linefmts[2] = Printf.Format(floatstr^7 * intstr * "\n")
-
-    terminal_header.header = """
-        model     logdt      logL   logTeff     logPs     logρs    H_cntr     iters
-         mass       age      logR     logTc     logPc     logρc   He_cntr     zones
-    -------------------------------------------------------------------------------
-    """
-end
-
-function setup_header(oz::OneZone)
-    lines = oz.network.nspecies ÷ 6 + 1
-    lastline = oz.network.nspecies % 6
-    if lastline == 0
-        terminal_header.linefmts = Vector{Printf.Format}(undef, lines)
-    else
-        terminal_header.linefmts = Vector{Printf.Format}(undef, lines + 1)
-    end
-    terminal_header.linefmts[1] = Printf.Format(intstr * floatstr^4 * intstr * "\n")
-
-    j = oz.network.nspecies
-    i = 2
-    while j > 6
-        terminal_header.linefmts[i] = Printf.Format(floatstr^6 * "\n")
-        j -= 6
-        i += 1
-    end
-    terminal_header.linefmts[end] = Printf.Format(floatstr^j * "\n")
-
-    terminal_header.header = """
-        model     logdt       age      logT      logρ     iters
-    """
-
-    for (j, species) in enumerate(oz.network.species_names)
-        if j % 6 != 1
-            speciesstr = lpad(String(species), width+1)
-        else
-            speciesstr = lpad(String(species), width)
-        end
-        terminal_header.header *= speciesstr
-        if j == oz.network.nspecies || j % 6 == 0
-            terminal_header.header *= "\n"
-        end
-    end
-
-    terminal_header.header *= """
-    -----------------------------------------------------------
-    """
-end
-
 function add_history_option!(m, name, unit, func; label::Union{LaTeXStrings.LaTeXString, String}="")
     if haskey(m.history_output_units, name)
         throw(ArgumentError("Key $name is already part of the history output options"))
@@ -170,21 +104,13 @@ function setup_model_profile_functions!(sm::StellarModel)
     add_profile_option!(sm, "D_face", "cm^2*s^{-1}", (sm, k) -> get_value(sm.props.turb_res[k].D_turb), label=L"D_\text{face}\,[\text{cm^2\,s^{-1}}]")
 end
 
-function init_IO(m::AbstractModel)
-    setup_header(m)
-    setup_model_history_functions!(m)
-    if isa(m, OneZone)
-        global ioinit = true
-        return
-    end
-    setup_model_profile_functions!(m)
-    global ioinit = true
+# One zone does not have profile info
+function setup_model_profile_functions!(oz::OneZone)
 end
 
-function clear_IO()
-    terminal_header.header = ""
-    terminal_header.linefmts = []
-    global ioinit = false
+function init_IO(m::AbstractModel)
+    setup_model_history_functions!(m)
+    setup_model_profile_functions!(m)
 end
 
 """
@@ -263,9 +189,6 @@ function shut_down_IO!(m)
     end
     if (m.opt.io.hdf5_profile_keep_open)
         close(m.profiles_file)
-    end
-    if ioinit
-        clear_IO()
     end
 end
 
@@ -405,11 +328,27 @@ function write_data(m::AbstractModel, ::Type{TNUMBER}=Float64) where {TNUMBER}
 end
 
 function write_terminal_info(sm::StellarModel; now::Bool=false)
-    if sm.props.model_number == 1 || sm.props.model_number % sm.opt.io.terminal_header_interval == 0 || now
-        print(terminal_header.header)
+    print_header = sm.props.model_number == 1 || sm.props.model_number % sm.opt.io.terminal_header_interval == 0 || now
+    print_step_info = sm.props.model_number == 1 || sm.props.model_number % sm.opt.io.terminal_info_interval == 0 || now
+    if !(print_header || print_step_info)
+        return
     end
-    if sm.props.model_number == 1 || sm.props.model_number % sm.opt.io.terminal_info_interval == 0 || now
-        Printf.format(stdout, terminal_header.linefmts[1],
+
+    if print_header
+        header = """
+            model     logdt      logL   logTeff     logPs     logρs    H_cntr     iters
+            mass       age      logR     logTc     logPc     logρc   He_cntr     zones
+        -------------------------------------------------------------------------------
+        """
+        print(header)
+    end
+    if print_step_info
+        width = 9
+        decimals = 4
+        floatstr = "%#$width.$decimals" * "g "
+        intstr = "%$width" * "i "
+        linefmt = Printf.Format(intstr * floatstr^6 * intstr * "\n")
+        Printf.format(stdout, linefmt,
                       sm.props.model_number,
                       log10(sm.props.dt / SECYEAR),
                       log10(get_value(sm.props.L[sm.props.nz])),
@@ -418,7 +357,8 @@ function write_terminal_info(sm::StellarModel; now::Bool=false)
                       log10(ℯ) * get_value(sm.props.lnρ[sm.props.nz]),
                       get_value(sm.props.xa[1, sm.network.xa_index[:H1]]),
                       sm.solver_data.newton_iters)
-        Printf.format(stdout, terminal_header.linefmts[2],
+        linefmt = Printf.Format(floatstr^7 * intstr * "\n")
+        Printf.format(stdout, linefmt,
                       sm.props.mstar / MSUN,
                       sm.props.time / SECYEAR,
                       log10(ℯ) * get_value(sm.props.lnr[sm.props.nz]) - log10(RSUN),
@@ -432,11 +372,60 @@ function write_terminal_info(sm::StellarModel; now::Bool=false)
 end
 
 function write_terminal_info(oz::OneZone; now::Bool=false)
-    if oz.props.model_number == 1 || oz.props.model_number % oz.opt.io.terminal_header_interval == 0 || now
-        print(terminal_header.header)
+    print_header = oz.props.model_number == 1 || oz.props.model_number % oz.opt.io.terminal_header_interval == 0 || now
+    print_step_info = oz.props.model_number == 1 || oz.props.model_number % oz.opt.io.terminal_info_interval == 0 || now
+    if !(print_header || print_step_info)
+        return
     end
-    if oz.props.model_number == 1 || oz.props.model_number % oz.opt.io.terminal_info_interval == 0 || now
-        Printf.format(stdout, terminal_header.linefmts[1],
+
+    width = 9
+
+    if print_header
+        header = """
+            model     logdt       age      logT      logρ     iters
+        """
+
+        for (j, species) in enumerate(oz.network.species_names)
+            if j % 6 != 1
+                speciesstr = lpad(String(species), width+1)
+            else
+                speciesstr = lpad(String(species), width)
+            end
+            header *= speciesstr
+            if j == oz.network.nspecies || j % 6 == 0
+                header *= "\n"
+            end
+        end
+
+        header *= """
+        -----------------------------------------------------------
+        """
+        print(header)
+    end
+    if print_step_info
+        decimals = 4
+        floatstr = "%#$width.$decimals" * "g "
+        intstr = "%$width" * "i "
+
+        lines = oz.network.nspecies ÷ 6 + 1
+        lastline = oz.network.nspecies % 6
+        if lastline == 0
+            linefmts = Vector{Printf.Format}(undef, lines)
+        else
+            linefmts = Vector{Printf.Format}(undef, lines + 1)
+        end
+        linefmts[1] = Printf.Format(intstr * floatstr^4 * intstr * "\n")
+
+        j = oz.network.nspecies
+        i = 2
+        while j > 6
+            linefmts[i] = Printf.Format(floatstr^6 * "\n")
+            j -= 6
+            i += 1
+        end
+        linefmts[end] = Printf.Format(floatstr^j * "\n")
+
+        Printf.format(stdout, linefmts[1],
                       oz.props.model_number,
                       log10(oz.props.dt / SECYEAR),
                       oz.props.time / SECYEAR,
@@ -446,11 +435,11 @@ function write_terminal_info(oz::OneZone; now::Bool=false)
         j = oz.network.nspecies
         i = 1
         while j > 6
-            Printf.format(stdout, terminal_header.linefmts[i + 1], (get_value.(oz.props.xa[((i - 1) * 6 + 1):(6i)]))...)
+            Printf.format(stdout, linefmts[i + 1], (get_value.(oz.props.xa[((i - 1) * 6 + 1):(6i)]))...)
             i += 1
             j -= 6
         end
-        Printf.format(stdout, terminal_header.linefmts[end], (get_value.(oz.props.xa[((i - 1) * 6 + 1):end]))...)
+        Printf.format(stdout, linefmts[end], (get_value.(oz.props.xa[((i - 1) * 6 + 1):end]))...)
         println()
     end
 end

--- a/src/StellarModels/OneZone.jl
+++ b/src/StellarModels/OneZone.jl
@@ -48,7 +48,8 @@ end
 Constructor for a `OneZone` instance, using `varnames` for the independent variables, the composition equation
 to be solved, number of independent variables `nvars`, number of species in the network `nspecies`
 """
-function OneZone(equation_set::AbstractEquationSet, network::NuclearNetwork, use_static_arrays=true, number_type=Float64)
+function OneZone(equation_set::AbstractEquationSet, network::NuclearNetwork, use_static_arrays=true,
+                    number_type=Float64, internal_dual_tag=ForwardDiff.Tag{:internal, nothing})
     nvars = network.nspecies
     var_names_full = network.species_names
     # link var_names to the correct index so you can do ind_var[vari[:lnT]] = 'some temperature'
@@ -57,11 +58,11 @@ function OneZone(equation_set::AbstractEquationSet, network::NuclearNetwork, use
         vari[var_names_full[i]] = i
     end
 
-    solver_data = build_solver_data_for_equation_set(equation_set, nvars, 1, 0, use_static_arrays, number_type)
+    solver_data = build_solver_data_for_equation_set(equation_set, nvars, 1, 0, use_static_arrays, number_type, internal_dual_tag)
 
     # properties
-    prv_step_props = OneZoneProperties(nvars, length(network.reactions), network.nspecies, number_type)
-    props = OneZoneProperties(nvars, length(network.reactions), network.nspecies, number_type)
+    prv_step_props = OneZoneProperties(nvars, length(network.reactions), network.nspecies, number_type, internal_dual_tag)
+    props = OneZoneProperties(nvars, length(network.reactions), network.nspecies, number_type, internal_dual_tag)
 
     opt = StellarModels.Options()  # create options object
 

--- a/src/StellarModels/OneZone.jl
+++ b/src/StellarModels/OneZone.jl
@@ -36,6 +36,7 @@ Structure definition of a model having one internal zone.
     history_file::HDF5.File
 
     # Output options
+    output_files_created::Bool = false
     history_output_units::Dict{String,String} = Dict()
     history_output_functions::Dict{String,Function} = Dict()
     history_output_labels::Dict{String,LaTeXStrings.LaTeXString} = Dict()

--- a/src/StellarModels/OneZoneProperties.jl
+++ b/src/StellarModels/OneZoneProperties.jl
@@ -24,10 +24,11 @@
     ϵ_nuc::TN
 end
 
-function OneZoneProperties(nvars::Int, nrates::Int, nspecies::Int, ::Type{TN}) where {TN<:Real}
+function OneZoneProperties(nvars::Int, nrates::Int, nspecies::Int,
+                            ::Type{TN}, ::Type{internal_tag}) where {TN<:Real, internal_tag<:ForwardDiff.Tag}
     # define the types
-    LDDTYPE = LocalDualData{nvars + 1,3 * nvars + 1,TN}  # full dual arrays
-    TDL = typeof(ForwardDiff.Dual(zero(TN), (zeros(TN, nvars))...))  # only the local duals
+    LDDTYPE = LocalDualData{nvars + 1,3 * nvars + 1,TN, internal_tag}  # full dual arrays
+    TDL = typeof(ForwardDiff.Dual{internal_tag}(zero(TN), (zeros(TN, nvars))...))  # only the local duals
 
     # create the vector containing the independent variables
     ind_vars = zeros(TN, nvars)
@@ -35,12 +36,12 @@ function OneZoneProperties(nvars::Int, nrates::Int, nspecies::Int, ::Type{TN}) w
     xa_dual = zeros(TDL, nvars)
     xa = Vector{LDDTYPE}(undef, nspecies)
     for j = 1:nspecies
-        xa[j] = LocalDualData(nvars, TN; is_ind_var=true, ind_var_i=nvars - nspecies + j)
+        xa[j] = LocalDualData(nvars, TN, internal_tag; is_ind_var=true, ind_var_i=nvars - nspecies + j)
     end
     rates_dual = zeros(TDL, nrates)
     rates = Vector{LDDTYPE}(undef, nrates)
     for k = 1:nrates
-        rates[k] = LocalDualData(nvars, TN)
+        rates[k] = LocalDualData(nvars, TN, internal_tag)
     end
 
     return OneZoneProperties(; ind_vars=ind_vars, model_number=zero(Int), dt=zero(TN), dt_next=zero(TN), time=zero(TN),

--- a/src/StellarModels/StellarModel.jl
+++ b/src/StellarModels/StellarModel.jl
@@ -46,6 +46,7 @@ differentiation, `TEOS` for the type of EOS being used and `TKAP` for the type o
     profiles_file::HDF5.File
 
     # Output options
+    output_files_created::Bool = false
     history_output_units::Dict{String,String} = Dict()
     history_output_functions::Dict{String,Function} = Dict()
     history_output_labels::Dict{String,LaTeXStrings.LaTeXString} = Dict()


### PR DESCRIPTION
Adresses #129 , also prevents continuing runs from erasing their hdf5 files, so a model can keep writing to the same file if the evolution loop is restarted.