### PR TITLE
Fix broken reallocation for remesh

### DIFF
--- a/examples/NuclearBurning.jl
+++ b/examples/NuclearBurning.jl
@@ -119,7 +119,7 @@ open("example_options.toml", "w") do file
           delta_Xc_limit = 0.005
 
           [termination]
-          max_model_number = 400
+          max_model_number = 2000
           max_center_T = 1e8
 
           [io]
@@ -151,7 +151,6 @@ plotter = Plotting.Plotter(fig=f,plots=plots);
 n = 3
 StellarModels.n_polytrope_initial_condition!(n, sm, nz, 0.7154, 0.0142, 0.0, Chem.abundance_lists[:ASG_09], 
                                             1 * MSUN, 100 * RSUN; initial_dt=10 * SECYEAR)
-##
 @time Evolution.do_evolution_loop!(sm, plotter=plotter);
 
 ##

--- a/src/StellarModels/Remesher.jl
+++ b/src/StellarModels/Remesher.jl
@@ -185,9 +185,17 @@ function adjust_props_size!(sm::StellarModel, new_nz::Int, nextra::Int)
     if sm.prv_step_props.nz > new_nz + nextra
         throw(ArgumentError("Can't fit model of size nz=$(sm.prv_step_props.nz) using new_nz=$(new_nz) and nextra=$(nextra)."))
     end
+
+    # Get the type of number being used
+    number_type = eltype(sm.props.ind_vars)
+    # get dual tag
+    # parameters[2] of typeof(sm.props) contains the Dual type used Internally
+    # With that, parameters[1] of a ForwardDiff.Dual will give the Tag
+    internal_tag = typeof(sm.props).parameters[2].parameters[1]
+
     # new properties object
-    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, network,
-                                       sm.vari, eltype(sm.prv_step_props.ind_vars))
+    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, sm.network,
+                                       sm.vari, number_type, internal_tag)
     # backup scalar quantities
     StellarModels.copy_scalar_properties!(adj_props, sm.start_step_props)
     # copy the mesh quantities (other properties are updated later)
@@ -195,20 +203,20 @@ function adjust_props_size!(sm::StellarModel, new_nz::Int, nextra::Int)
     sm.start_step_props = adj_props
 
     # also the props used later need new size:
-    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, network,
-                                       sm.vari, eltype(sm.prv_step_props.ind_vars))
+    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, sm.network,
+                                       sm.vari, number_type, internal_tag)
     StellarModels.copy_scalar_properties!(adj_props, sm.props)
     StellarModels.copy_mesh_properties!(sm, adj_props, sm.props)
     sm.props = adj_props
 
     # prv_step_props is also reallocated to be sure all have the same size
-    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, network,
-                                       sm.vari, eltype(sm.prv_step_props.ind_vars))
+    adj_props = build_properties_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra, sm.network,
+                                       sm.vari, number_type, internal_tag)
     StellarModels.copy_scalar_properties!(adj_props, sm.prv_step_props)
     StellarModels.copy_mesh_properties!(sm, adj_props, sm.prv_step_props)
     sm.prv_step_props = adj_props
 
     # also the solver needs new arrays!
-    sm.solver_data = StellarModels.SolverData(sm.nvars, new_nz, nextra, sm.solver_data.use_static_arrays,
-                                              eltype(sm.prv_step_props.ind_vars))
+    sm.solver_data = build_solver_data_for_equation_set(sm.equation_set, sm.nvars, new_nz, nextra,
+                                sm.solver_data.use_static_arrays, number_type, internal_tag)
 end


### PR DESCRIPTION
Loosely connected to #108 . At some point the code that reallocates arrays once we exceed the buffer given by `nextra` broke. This PR fixes that.